### PR TITLE
Added numpad support.

### DIFF
--- a/sp/index.html
+++ b/sp/index.html
@@ -93,6 +93,14 @@
 		var DownArrow=40;
 		var LeftArrow=37;
 		var RightArrow=39;
+		var numpad1 = 97;
+		var numpad2 = 98;
+		var numpad3 = 99;
+		var numpad4 = 100;
+		var numpad6 = 102;
+		var numpad7 = 103;
+		var numpad8 = 104;
+		var numpad9 = 105;
 		var pi = Math.PI;
 		var score = -1;
 		var l_score = "N/A";
@@ -194,16 +202,34 @@
 
 			// Update players location
 			update: function(){
-				// Movements
-				if(keystate[UpArrow]) this.loc_y -=this.speed;
-				if(keystate[DownArrow]) this.loc_y +=this.speed;
-				if(keystate[LeftArrow]) this.loc_x -=this.speed;
-				if(keystate[RightArrow]) this.loc_x +=this.speed;
+				// Orthogonal Movements
+				if(keystate[UpArrow] || keystate[numpad8]) this.loc_y -=this.speed;
+				if(keystate[DownArrow] || keystate[numpad2]) this.loc_y +=this.speed;
+				if(keystate[LeftArrow] || keystate[numpad4]) this.loc_x -=this.speed;
+				if(keystate[RightArrow] || keystate[numpad6]) this.loc_x +=this.speed;
 
 				if(keystate[UpButton]) this.loc_y -=this.speed;
 				if(keystate[DownButton]) this.loc_y +=this.speed;
 				if(keystate[LeftButton]) this.loc_x -=this.speed;
 				if(keystate[RightButton]) this.loc_x +=this.speed;
+				
+				// Diagonal Movements
+				if(keystate[numpad1]) {
+					this.loc_y += this.speed;
+					this.loc_x -= this.speed;
+				}
+				if(keystate[numpad3]) {
+					this.loc_y += this.speed;
+					this.loc_x += this.speed;
+				}
+				if(keystate[numpad7]) {
+					this.loc_y -= this.speed;
+					this.loc_x -= this.speed;
+				}
+				if(keystate[numpad9]) {
+					this.loc_y -= this.speed;
+					this.loc_x += this.speed;
+				}
 
 				// Set the limits for the player
 				this.loc_y = Math.max(Math.min(this.loc_y, HEIGHT - this.radius), this.radius);


### PR DESCRIPTION
The game now fully works with all of the numpad directional keys. The player can now move diagonally by pressing only one key.

Issues:
- Diagonal movement is faster than orthogonal movement due to the grid representation used. Fixing this will require changes to the movement system as a whole.
- By holding two adjacent numpad keys the player will gain added speed. For example, holding 1 moves the player left at a rate of "speed" and down at a rate of "speed". Holding 2 as well moves the player left at a rate of "speed" and down at a rate of "2*speed".
